### PR TITLE
US119T151 fixed update button to only update topics and add new ones

### DIFF
--- a/Frontend/src/viewpane/viewpane.jsx
+++ b/Frontend/src/viewpane/viewpane.jsx
@@ -139,15 +139,22 @@ class Viewpane extends React.Component {
         }).then(response => response.json())
             .then(response => {
                 let that = this;        // TODO: Fix call back referencing, this isn't the best means of accomplishing task.
+                let t = that.state.topics;
+                let c = that.state.comments;
                 response.forEach(function (obj) {
                     // console.log("ITER",obj); 
-                    let t = that.state.topics;
-                    t.push(obj);
-                    that.setState({ topics: t });
-                    let c = that.state.comments;
-                    c.push({ 'id': obj.topic_title, 'comment': [] });
-                    that.setState({ comments: c });
+                    let idx = t.findIndex(x => x.topic_title === obj.topic_title);
+                    if (idx === -1){
+                        t.push(obj);
+                        c.push({ 'id': obj.topic_title, 'comment': [] });
+                    }
+                    else{
+                        t[idx] = obj;
+                        // eventually comment updates but for now unnecessary;
+                    }
                 });
+                that.setState({ topics: t });
+                that.setState({ comments: c });
             })
     }
 


### PR DESCRIPTION
To test:
login to a user with some topics, click update, click update a few more times (make sure no new or repeat topics appear)
logout and login to another user, repeat above process.
update should only update existing topics, or add new ones, not add existing topics repeatedly